### PR TITLE
Fix: icon is sometimes not fetched correctly for extended view

### DIFF
--- a/__tests__/__snapshots__/subcomponents.test.tsx.snap
+++ b/__tests__/__snapshots__/subcomponents.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
           <img
             className="expanded-view-icon"
             height={20}
-            src="http://www.google.com/s2/favicons?domain=w3schools.com"
+            src="https://icons.duckduckgo.com/ip3/w3schools.com.ico"
             width={20}
           />
         </div>
@@ -55,7 +55,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
           <img
             className="expanded-view-icon"
             height={20}
-            src="http://www.google.com/s2/favicons?domain=ackoverflow.com"
+            src="https://icons.duckduckgo.com/ip3/ackoverflow.com.ico"
             width={20}
           />
         </div>
@@ -93,7 +93,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
           <img
             className="expanded-view-icon"
             height={20}
-            src="http://www.google.com/s2/favicons?domain=github.com"
+            src="https://icons.duckduckgo.com/ip3/github.com.ico"
             width={20}
           />
         </div>
@@ -131,7 +131,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
           <img
             className="expanded-view-icon"
             height={20}
-            src="http://www.google.com/s2/favicons?domain=google.com"
+            src="https://icons.duckduckgo.com/ip3/google.com.ico"
             width={20}
           />
         </div>
@@ -169,7 +169,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
           <img
             className="expanded-view-icon"
             height={20}
-            src="http://www.google.com/s2/favicons?domain=npmjs.com"
+            src="https://icons.duckduckgo.com/ip3/npmjs.com.ico"
             width={20}
           />
         </div>

--- a/__tests__/subcomponents.test.tsx
+++ b/__tests__/subcomponents.test.tsx
@@ -44,14 +44,14 @@ describe("ShrinkedView", () => {
     it("renders icon as image with proper src when icon is available on website", async () => {
         global.browser.tabs.query = () => {
             return new Promise((resolve) => {
-                resolve([{url: "proper-existing-icon-url"}]);
+                resolve([{url: "proper.existing.icon.url"}]);
             });
         };
         const shrinkedView = await renderElementAsObject(<ShrinkedView />);
         const img = getChild(getChild(shrinkedView, 0), 0);
         expect(img).toBeDefined();
         expect(img.type).toBe("img");
-        expect(img.props.src).toContain("http://www.google.com/s2/favicons?domain=proper-existing-icon-url");
+        expect(img.props.src).toContain("https://icons.duckduckgo.com/ip3/proper.existing.icon.url.ico");
     });
 
     it("displays 0 time spent for incorrect domain", async () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -42,7 +42,7 @@ describe("getWebsiteIconObject", () => {
         const fakeWebsiteURL = "fake-website-url";
         expect(getWebsiteIconObject(fakeWebsiteURL)).toEqual({
             size: 20,
-            src: "http://www.google.com/s2/favicons?domain=fake-website-url",
+            src: "https://icons.duckduckgo.com/ip3/fake-website-url.ico",
         });
     });
 

--- a/app/src/popup/Utils.ts
+++ b/app/src/popup/Utils.ts
@@ -16,7 +16,7 @@ export const getWebsiteIconObject = (websiteURL: string | undefined): Icon => {
     const iconDesiredSize = 20;
     const iconSource: string =
         websiteURL && websiteURL.length
-            ? `http://www.google.com/s2/favicons?domain=${websiteURL}`
+            ? `https://icons.duckduckgo.com/ip3/${websiteURL}.ico`
             : "../resources/missing-website-favicon.png";
 
     const icon: Icon = {

--- a/app/src/popup/subcomponents/ShrinkedView.tsx
+++ b/app/src/popup/subcomponents/ShrinkedView.tsx
@@ -3,9 +3,9 @@ import {getActiveTabDomainFromURL, getHours, getMinutes, getSeconds, getWebsiteI
 import browser from "webextension-polyfill";
 import Database from "../../engine/Database";
 
-const getCurrentTimeForCurrentUrl = (domain: string): number => {
+const getCurrentTimeForCurrentDomain = (domain: string): number => {
     const db = new Database();
-    const timeSpent = (db.readTimeSpent(getActiveTabDomainFromURL(domain) || "") as number) || 0;
+    const timeSpent = (db.readTimeSpent(domain) as number) || 0;
     return timeSpent;
 };
 
@@ -18,9 +18,10 @@ export const ShrinkedView = () => {
         browser.tabs
             .query({active: true})
             .then((result) => {
-                setIcon(getWebsiteIconObject(result[0].url));
-                setTimeInSeconds(getCurrentTimeForCurrentUrl(result[0].url!));
-                setActiveDomain(getActiveTabDomainFromURL(result[0].url!) || "");
+                const domain = getActiveTabDomainFromURL(result[0].url!) || "";
+                setIcon(getWebsiteIconObject(domain));
+                setTimeInSeconds(getCurrentTimeForCurrentDomain(domain));
+                setActiveDomain(domain);
             })
             .catch((error: Error) => {
                 console.error(error.message);


### PR DESCRIPTION
This pull request fixes the issue, where an icon was not always available when fetching it for extended view.
The reason was that the Google fetching API did not always use the same URL for fetching between basic and extended view, so icon was fetched with incorrect URL causing 404 code.
The fix for that is to use a different engine: duckduck.go.