### PR TITLE
Fix: Domain parsed incorrectly for websites starting with "m"

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -35,6 +35,12 @@ describe("getActiveTabDomainFromURL", () => {
         );
         expect(getActiveTabDomainFromURL("https://www.santander.pl/klient-indywidualny")).toBe("santander.pl");
     });
+
+    it("correctly parses domains that contains w at the beginning", () => {
+        expect(getActiveTabDomainFromURL("https://wybory2011.pkw.gov.pl/wsw/pl/000000.html")).toBe("wybory2011.pkw.gov.pl");
+        expect(getActiveTabDomainFromURL("https://wiadomosci.onet.pl/inwazja-rosji-na-ukraine")).toBe("wiadomosci.onet.pl");
+        expect(getActiveTabDomainFromURL("https://www.wroclaw.pl/dla-mieszkanca/aktualnosci")).toBe("wroclaw.pl");
+    })
 });
 
 describe("getWebsiteIconObject", () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -37,10 +37,14 @@ describe("getActiveTabDomainFromURL", () => {
     });
 
     it("correctly parses domains that contains w at the beginning", () => {
-        expect(getActiveTabDomainFromURL("https://wybory2011.pkw.gov.pl/wsw/pl/000000.html")).toBe("wybory2011.pkw.gov.pl");
-        expect(getActiveTabDomainFromURL("https://wiadomosci.onet.pl/inwazja-rosji-na-ukraine")).toBe("wiadomosci.onet.pl");
+        expect(getActiveTabDomainFromURL("https://wybory2011.pkw.gov.pl/wsw/pl/000000.html")).toBe(
+            "wybory2011.pkw.gov.pl"
+        );
+        expect(getActiveTabDomainFromURL("https://wiadomosci.onet.pl/inwazja-rosji-na-ukraine")).toBe(
+            "wiadomosci.onet.pl"
+        );
         expect(getActiveTabDomainFromURL("https://www.wroclaw.pl/dla-mieszkanca/aktualnosci")).toBe("wroclaw.pl");
-    })
+    });
 });
 
 describe("getWebsiteIconObject", () => {

--- a/app/src/popup/Utils.ts
+++ b/app/src/popup/Utils.ts
@@ -8,7 +8,8 @@ export interface Icon {
 export const getActiveTabDomainFromURL = (URL: string): string | null => {
     let result = URL.replace("https://", "");
     result = result.replace("http://", "");
-    const results = result.match(/[^w.][^ /]+/g);
+    result = result.replace("www.", "");
+    const results = result.match(/[^ /]+/g);
     return results && !results[0].includes(" ") && results[0].includes(".") ? results[0] : null;
 };
 


### PR DESCRIPTION
This pull request fixes #12 
It is a followup of another fix that was done regarding the "https" pre string and this one fixes the issue where "w" character is incorrectly cut from domain regarding the "www." substring.