### PR TITLE
Handle browser focus and blur regarding time summary

### DIFF
--- a/app/src/engine/Background.ts
+++ b/app/src/engine/Background.ts
@@ -15,10 +15,6 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     }
 });
 
-window.addEventListener("focus", (ev) => {
-    console.log("Focus event: ", ev);
-});
-
 browser.windows.onFocusChanged.addListener((id) => {
     const windowInactiveID = -1;
     const db = new Database();

--- a/app/src/engine/Background.ts
+++ b/app/src/engine/Background.ts
@@ -1,15 +1,29 @@
-import browser from "webextension-polyfill";
+import browser, { windows } from "webextension-polyfill";
 import {getActiveTabDomainFromURL} from "../popup/Utils";
 import {storeTimeSpentSummary} from "../popup/Utils";
+import Database from "./Database";
 
 browser.tabs.onActivated.addListener((activeInfo) => {
+    const db = new Database();
     browser.tabs.get(activeInfo.tabId).then((tab) => {
         storeTimeSpentSummary(getActiveTabDomainFromURL(tab?.url || "") || "");
     });
 });
 
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    const db = new Database();
     if (changeInfo.status == "complete") {
         storeTimeSpentSummary(getActiveTabDomainFromURL(tab.url || "") || "");
+    }
+});
+
+window.addEventListener("focus", (ev) => {
+    console.log("Focus event: ", ev);
+});
+
+browser.windows.onFocusChanged.addListener((id) => {
+    if(id === windows.WINDOW_ID_NONE) {
+        const db = new Database();
+        db.writePreviousDomain("no previous domain");
     }
 });

--- a/app/src/popup/Utils.ts
+++ b/app/src/popup/Utils.ts
@@ -34,12 +34,16 @@ export function storeTimeSpentSummary(currentDomain: string) {
     if (currentDomain.length > 0 && previousDomain !== currentDomain) {
         db.writePreviousDomain(currentDomain);
         db.writeLastActive(currentDomain, new Date());
-
-        const lastActive = db.readLastActive(previousDomain);
-        const timeSpent = Math.trunc(Math.abs(Date.now() - lastActive.getTime()) / 1000);
-        const totalTimeSpentOfLastActive = (db.readTimeSpent(previousDomain) as number) + timeSpent;
-        db.writeTimeSpent(previousDomain, totalTimeSpentOfLastActive);
+        calculateTimeSpentForDomain(previousDomain);
     }
+}
+
+export function calculateTimeSpentForDomain(domain: string) {
+    const db = new Database();
+    const lastActive = db.readLastActive(domain);
+    const timeSpent = Math.trunc(Math.abs(Date.now() - lastActive.getTime()) / 1000);
+    const totalTimeSpentOfLastActive = (db.readTimeSpent(domain) as number) + timeSpent;
+    db.writeTimeSpent(domain, totalTimeSpentOfLastActive);
 }
 
 export const howManyHoursInSeconds = (timeInSeconds: number): number => {


### PR DESCRIPTION
This pull request fixes #21 
It correctly handles the event of browser losing and gaining focus by:
* on losing focus the time of previously active tab is summarized and the active tab field is cleared indicating no website is visited
* on gaining focus the currently active website is written as previously active and the timestamp of last visit is written as the moment of getting back to the browser window