### PR TITLE
Open a visited domain by clicking the domain's name

### DIFF
--- a/__tests__/__snapshots__/subcomponents.test.tsx.snap
+++ b/__tests__/__snapshots__/subcomponents.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
         >
           <div
             className="expanded-view-domain-text"
+            onClick={[Function]}
           >
             w3schools.com
           </div>
@@ -64,6 +65,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
         >
           <div
             className="expanded-view-domain-text"
+            onClick={[Function]}
           >
             ackoverflow.com
           </div>
@@ -102,6 +104,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
         >
           <div
             className="expanded-view-domain-text"
+            onClick={[Function]}
           >
             github.com
           </div>
@@ -140,6 +143,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
         >
           <div
             className="expanded-view-domain-text"
+            onClick={[Function]}
           >
             google.com
           </div>
@@ -178,6 +182,7 @@ exports[`ExpandedView renders correctly according to snapshot 1`] = `
         >
           <div
             className="expanded-view-domain-text"
+            onClick={[Function]}
           >
             npmjs.com
           </div>

--- a/app/src/popup/Popup.css
+++ b/app/src/popup/Popup.css
@@ -101,6 +101,13 @@
 .expanded-view-domain-text {
   font-family: Georgia, 'Times New Roman', Times, serif;
   font-size: medium;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.expanded-view-domain-text:hover {
+  text-decoration: underline;
+  color: #FC4D17;
+  text-decoration-color: #FC4D17;
 }
 .expanded-view-time-spent-text-container {
   width: 100px;

--- a/app/src/popup/subcomponents/ExpandedView.tsx
+++ b/app/src/popup/subcomponents/ExpandedView.tsx
@@ -23,7 +23,9 @@ export const ExpandedView = () => {
                     <img className="expanded-view-icon" width={icon.size} height={icon.size} src={icon.src} />
                 </div>
                 <div className="expanded-view-domain-container">
-                    <div className="expanded-view-domain-text">{domain}</div>
+                    <div className="expanded-view-domain-text" onClick={() => 
+                        open(`https://www.${domain}/`, Window.name)
+                    } >{domain}</div>
                 </div>
                 <div className="expanded-view-time-spent-text-container">
                     <div className="expanded-view-time-spent-text">

--- a/app/src/popup/subcomponents/ExpandedView.tsx
+++ b/app/src/popup/subcomponents/ExpandedView.tsx
@@ -23,9 +23,11 @@ export const ExpandedView = () => {
                     <img className="expanded-view-icon" width={icon.size} height={icon.size} src={icon.src} />
                 </div>
                 <div className="expanded-view-domain-container">
-                    <div className="expanded-view-domain-text" onClick={() => 
-                        open(`https://www.${domain}/`, Window.name)
-                    } >{domain}</div>
+                    <div
+                        className="expanded-view-domain-text"
+                        onClick={() => open(`https://www.${domain}/`, Window.name)}>
+                        {domain}
+                    </div>
                 </div>
                 <div className="expanded-view-time-spent-text-container">
                     <div className="expanded-view-time-spent-text">


### PR DESCRIPTION
This pull request closes #25 
It allows to open the domain's website by clicking the name of the domain in the visited website tile.

NOTE: It opens only the main homepage of the domain.