### PR TITLE
Release: v1.2.0

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "How long I've been here?",
-  "version": "1.0.1",
+  "version": "1.2.0",
 
   "permissions": [
     "activeTab",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "how-long-ive-been-here",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "how-long-ive-been-here",
-      "version": "1.0.1",
+      "version": "1.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@babel/cli": "^7.14.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "how-long-ive-been-here",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Mozilla Firefox extension plugin to monitor the time spent on a website",
   "main": "manifest.json",
   "scripts": {


### PR DESCRIPTION
This pull request releases version 1.2.0 with the website's name now being clickable as a link opening the selected website in a new tab (by default).
To be merged when application passes the Mozilla review.